### PR TITLE
Show which arguments that have been called for the mock

### DIFF
--- a/lib/tunit/faux/reporters.rb
+++ b/lib/tunit/faux/reporters.rb
@@ -1,3 +1,4 @@
-require "tunit/faux/reporters/method_name"
 require "tunit/faux/reporters/arguments"
+require "tunit/faux/reporters/base"
+require "tunit/faux/reporters/method_name"
 require "tunit/faux/reporters/times"

--- a/lib/tunit/faux/reporters/arguments.rb
+++ b/lib/tunit/faux/reporters/arguments.rb
@@ -1,17 +1,9 @@
-require "tunit/mock"
+require "tunit/faux/reporters/base"
 
 module Tunit
   module Faux
     module Reporters
-      class Arguments
-        attr_reader :method_name, :arguments, :mock
-
-        def initialize(method_name:, arguments:, mock:)
-          @method_name = method_name
-          @arguments = Array(arguments)
-          @mock = mock
-        end
-
+      class Arguments < Base
         def run
           mock.calls.any? do |call|
             same_arguments?(call) || same_argument_type?(call)
@@ -20,9 +12,7 @@ module Tunit
 
         def report
           if violation?
-            "Expected #{mock.class}##{method_name} to have been called " +
-              "with #{arguments.inspect}, " +
-              "was called with #{violating_call.arguments.inspect}"
+            "#{base_message}, was called with #{violating_call.arguments}"
           end
         end
 
@@ -41,8 +31,8 @@ module Tunit
         end
 
         def same_argument_type?(call)
-          call.arguments.all? do |argument|
-            arguments.first === argument
+          call.arguments.any? && call.arguments.all? do |argument|
+            argument.class.ancestors.include?(arguments.first)
           end
         end
       end

--- a/lib/tunit/faux/reporters/base.rb
+++ b/lib/tunit/faux/reporters/base.rb
@@ -1,0 +1,22 @@
+module Tunit
+  module Faux
+    module Reporters
+      class Base
+        attr_reader :arguments, :mock, :times, :method_name
+
+        def initialize(arguments: [], method_name:, mock:, times: 1)
+          @arguments = Array(arguments)
+          @method_name = method_name
+          @mock = mock
+          @times = times
+        end
+
+        private
+
+        def base_message
+          "Expected #{mock.class}##{method_name}#{arguments} to have been called"
+        end
+      end
+    end
+  end
+end

--- a/lib/tunit/faux/reporters/method_name.rb
+++ b/lib/tunit/faux/reporters/method_name.rb
@@ -1,14 +1,9 @@
+require "tunit/faux/reporters/base"
+
 module Tunit
   module Faux
     module Reporters
-      class MethodName
-        attr_reader :method_name, :mock
-
-        def initialize(method_name:, mock:)
-          @method_name = method_name
-          @mock = mock
-        end
-
+      class MethodName < Base
         def run
           mock.calls.any? do |call|
             call.method_name == method_name
@@ -17,7 +12,7 @@ module Tunit
 
         def report
           if violation?
-            "Expected #{mock.class}##{method_name} to have been called"
+            base_message.strip
           end
         end
 

--- a/lib/tunit/faux/reporters/times.rb
+++ b/lib/tunit/faux/reporters/times.rb
@@ -1,23 +1,17 @@
+require "tunit/faux/reporters/base"
+
 module Tunit
   module Faux
     module Reporters
-      class Times
-        attr_reader :method_name, :times, :mock
-
-        def initialize(method_name:, times:, mock:)
-          @method_name = method_name
-          @times = times
-          @mock = mock
-        end
-
+      class Times < Base
         def run
           number_of_invocations == times
         end
 
         def report
           if violation?
-            "Expected #{mock.class}##{method_name} to have been called " +
-              "#{times} #{pluralize_times(times)}, " +
+            base_message +
+              " #{times} #{pluralize_times(times)}, " +
               "was called " +
               "#{number_of_invocations} #{pluralize_times(number_of_invocations)}"
           end

--- a/lib/tunit/faux/settler.rb
+++ b/lib/tunit/faux/settler.rb
@@ -3,12 +3,12 @@ require "tunit/faux/reporters"
 module Tunit
   module Faux
     class Settler
-      attr_reader :mock, :method_name, :arguments, :times
+      attr_reader :arguments, :method_name, :times, :mock
 
-      def initialize(mock: nil, method_name: nil, arguments: [], times: 1)
-        @mock = mock
-        @method_name = method_name
+      def initialize(arguments: [], method_name:, mock:, times: 1)
         @arguments = Array(arguments)
+        @method_name = method_name
+        @mock = mock
         @times = times
       end
 
@@ -27,21 +27,17 @@ module Tunit
 
       def reporters
         @reporters ||= [
-          Reporters::MethodName.new(
-            method_name: method_name,
-            mock: mock,
-          ),
-          Reporters::Arguments.new(
-            method_name: method_name,
+          Reporters::MethodName,
+          Reporters::Arguments,
+          Reporters::Times,
+        ].map do |reporter_klass|
+          reporter_klass.new(
             arguments: arguments,
-            mock: mock,
-          ),
-          Reporters::Times.new(
             method_name: method_name,
-            times: times,
             mock: mock,
-          ),
-        ]
+            times: times,
+          )
+        end
       end
     end
   end

--- a/test/tunit/faux/reporters/arguments_test.rb
+++ b/test/tunit/faux/reporters/arguments_test.rb
@@ -15,11 +15,11 @@ module Tunit::Faux::Reporters
 
     def test_run_arguments_of_same_type
       mock = Tunit::Mock.new
-      reporter = Arguments.new(method_name: :foo, arguments: Fixnum, mock: mock)
+      reporter = Arguments.new(method_name: :foo, arguments: [Time.now], mock: mock)
 
-      mock.foo(9999)
+      mock.foo
 
-      assert reporter.run
+      refute reporter.run
     end
 
     def test_report_violation
@@ -29,7 +29,7 @@ module Tunit::Faux::Reporters
       mock.foo(2)
 
       exp_report = <<-EOS
-        Expected Tunit::Mock#foo to have been called with [1], was called with [2]
+        Expected Tunit::Mock#foo[1] to have been called, was called with [2]
       EOS
 
       assert_equal exp_report.strip, reporter.report

--- a/test/tunit/faux/reporters/method_name_test.rb
+++ b/test/tunit/faux/reporters/method_name_test.rb
@@ -6,7 +6,10 @@ module Tunit::Faux::Reporters
   class MethodNameTest < Minitest::Test
     def test_run
       mock = Tunit::Mock.new
-      reporter = MethodName.new(method_name: :foo, mock: mock)
+      reporter = MethodName.new(
+        method_name: :foo,
+        mock: mock,
+      )
 
       mock.foo
 
@@ -29,7 +32,7 @@ module Tunit::Faux::Reporters
       mock.bar
 
       exp_report = <<-EOS
-        Expected Tunit::Mock#foo to have been called
+        Expected Tunit::Mock#foo[] to have been called
       EOS
 
       assert_equal exp_report.strip, reporter.report

--- a/test/tunit/faux/reporters/times_test.rb
+++ b/test/tunit/faux/reporters/times_test.rb
@@ -31,7 +31,7 @@ module Tunit::Faux::Reporters
       mock.foo
 
       exp_report = <<-EOS
-        Expected Tunit::Mock#foo to have been called 1 time, was called 2 times
+        Expected Tunit::Mock#foo[] to have been called 1 time, was called 2 times
       EOS
 
       assert_equal exp_report.strip, reporter.report

--- a/test/tunit/faux/settler_test.rb
+++ b/test/tunit/faux/settler_test.rb
@@ -4,37 +4,6 @@ require "tunit/mock"
 
 module Tunit::Faux
   class SettlerTest < Minitest::Test
-    def test_mock
-      mock = Tunit::Mock.new
-      settler = Settler.new(mock: mock)
-
-      assert_equal mock, settler.mock
-    end
-
-    def test_method_name
-      settler = Settler.new(method_name: :foo)
-
-      assert_equal :foo, settler.method_name
-    end
-
-    def test_arguments
-      settler = Settler.new(arguments: 2)
-
-      assert_equal [2], settler.arguments
-    end
-
-    def test_times
-      settler = Settler.new(times: 2)
-
-      assert_equal 2, settler.times
-    end
-
-    def test_times_fallback
-      settler = Settler.new
-
-      assert_equal 1, settler.times
-    end
-
     def test_satisfied_eh_method_name
       mock = Tunit::Mock.new
       settler = Settler.new(mock: mock, method_name: :foo)
@@ -81,7 +50,7 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo to have been called
+        Expected Tunit::Mock#foo[] to have been called
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip
@@ -96,7 +65,7 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo to have been called with [1], was called with [2]
+        Expected Tunit::Mock#foo[1] to have been called, was called with [2]
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip
@@ -111,7 +80,29 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo to have been called 2 times, was called 1 time
+        Expected Tunit::Mock#foo[] to have been called 2 times, was called 1 time
+      EOS
+
+      assert_equal exp_message.strip, settler.reason.strip
+    end
+
+    def test_reason_times_with_arguments
+      mock = Tunit::Mock.new
+      settler = Settler.new(
+        arguments: 1,
+        method_name: :foo,
+        mock: mock,
+        times: 2,
+      )
+
+      mock.foo(1)
+      mock.foo(1)
+      mock.foo(1)
+
+      refute_predicate settler, :satisfied?
+
+      exp_message = <<-EOS.strip_heredoc
+        Expected Tunit::Mock#foo[1] to have been called 2 times, was called 3 times
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip


### PR DESCRIPTION
- Refactor: introduce `Reporters::Base#_base_message` to remove
  duplication for the base part of the message. The message is formatted
  as:
  
  `Expected CLASS#METHOD_NAME[ARGUMENTS] to have been called DESCRIPTION`
  - `CLASS` is the name of the mock-class.
  - `METHOD_NAME` is the name of the mocked method.
  - `[ARGUMENTS]` are the arguments of the mocked method. If the
    argument is `1`, it will be written as `[1]`. If there are no
    arguments, it will be written as `[]`.
  - `DESCRIPTION` will be filled in by the reporters for their specific needs.
- Refactor: Pass all arguments to the reporters.
  - Simplify `Settler#_reporters`.
  - Introduce `Reporters::Base` with a shared constructor.
