### PR TITLE
Support different kinds of Mocks

### DIFF
--- a/lib/tunit/mock.rb
+++ b/lib/tunit/mock.rb
@@ -1,29 +1,16 @@
+require "tunit/mock/double"
+require "tunit/mock/null_object"
+
 module Tunit
-  class Mock
-    attr_reader :name, :calls
+  module Mock
+    TYPE_LOOKUP = {
+      null_object: NullObject,
+      spy: Spy,
+    }
+    TYPE_LOOKUP.default = Double
 
-    def initialize(name: :mock)
-      @name = name
-      @calls = []
-    end
-
-    def method_missing(method_name, *args, &block)
-      calls << MetohodCall.new(
-        method_name: method_name,
-        arguments: args,
-        block: block,
-      )
-      method_name
-    end
-
-    class MetohodCall
-      attr_reader :method_name, :arguments, :block
-
-      def initialize(method_name:, arguments:, block:)
-        @method_name = method_name
-        @arguments = Array(arguments)
-        @block = block || -> {}
-      end
+    def self.new(type = nil)
+      TYPE_LOOKUP[type].new
     end
   end
 end

--- a/lib/tunit/mock/base.rb
+++ b/lib/tunit/mock/base.rb
@@ -1,0 +1,30 @@
+module Tunit
+  module Mock
+    class Base
+      attr_reader :calls
+
+      def initialize
+        @calls = []
+      end
+
+      def method_missing(method_name, *args, &block)
+        calls << MetohodCall.new(
+          method_name: method_name,
+          arguments: args,
+          block: block,
+        )
+        method_name
+      end
+
+      class MetohodCall
+        attr_reader :method_name, :arguments, :block
+
+        def initialize(method_name:, arguments:, block:)
+          @method_name = method_name
+          @arguments = Array(arguments)
+          @block = block || -> {}
+        end
+      end
+    end
+  end
+end

--- a/lib/tunit/mock/double.rb
+++ b/lib/tunit/mock/double.rb
@@ -1,0 +1,25 @@
+require "tunit/mock/base"
+
+module Tunit
+  module Mock
+    class Double < Base
+      UnexpectedMethod = Class.new(Exception)
+
+      attr_reader :expected_methods
+
+      def initialize(**methods)
+        super()
+        @expected_methods = methods
+      end
+
+      def method_missing(method_name, *args, &block)
+        if expected_methods.has_key?(method_name)
+          super
+          expected_methods[method_name]
+        else
+          raise UnexpectedMethod, "`#{method_name}' was not expected to be called"
+        end
+      end
+    end
+  end
+end

--- a/lib/tunit/mock/null_object.rb
+++ b/lib/tunit/mock/null_object.rb
@@ -1,0 +1,15 @@
+require "tunit/mock/base"
+
+module Tunit
+  module Mock
+    class NullObject < Base
+      def method_missing(method_name, *args, &block)
+        super
+        self
+      end
+    end
+
+    class Spy < NullObject
+    end
+  end
+end

--- a/test/tunit/faux/reporters/arguments_test.rb
+++ b/test/tunit/faux/reporters/arguments_test.rb
@@ -5,7 +5,7 @@ require "tunit/mock"
 module Tunit::Faux::Reporters
   class ArgumentsTest < Minitest::Test
     def test_run_same_arguments
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Arguments.new(method_name: :foo, arguments: 1, mock: mock)
 
       mock.foo(1)
@@ -14,7 +14,7 @@ module Tunit::Faux::Reporters
     end
 
     def test_run_arguments_of_same_type
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Arguments.new(method_name: :foo, arguments: [Time.now], mock: mock)
 
       mock.foo
@@ -23,20 +23,20 @@ module Tunit::Faux::Reporters
     end
 
     def test_report_violation
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Arguments.new(method_name: :foo, arguments: 1, mock: mock)
 
       mock.foo(2)
 
       exp_report = <<-EOS
-        Expected Tunit::Mock#foo[1] to have been called, was called with [2]
+        Expected Tunit::Mock::Spy#foo[1] to have been called, was called with [2]
       EOS
 
       assert_equal exp_report.strip, reporter.report
     end
 
     def test_report_bug
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Arguments.new(method_name: :foo, arguments: [], mock: mock)
 
       mock.bar

--- a/test/tunit/faux/reporters/method_name_test.rb
+++ b/test/tunit/faux/reporters/method_name_test.rb
@@ -5,7 +5,7 @@ require "tunit/mock"
 module Tunit::Faux::Reporters
   class MethodNameTest < Minitest::Test
     def test_run
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = MethodName.new(
         method_name: :foo,
         mock: mock,
@@ -17,7 +17,7 @@ module Tunit::Faux::Reporters
     end
 
     def test_run_verifies_that_target_was_called_on_mock
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = MethodName.new(method_name: :foo, mock: mock)
 
       mock.bar
@@ -26,13 +26,13 @@ module Tunit::Faux::Reporters
     end
 
     def test_report
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = MethodName.new(method_name: :foo, mock: mock)
 
       mock.bar
 
       exp_report = <<-EOS
-        Expected Tunit::Mock#foo[] to have been called
+        Expected Tunit::Mock::Spy#foo[] to have been called
       EOS
 
       assert_equal exp_report.strip, reporter.report

--- a/test/tunit/faux/reporters/times_test.rb
+++ b/test/tunit/faux/reporters/times_test.rb
@@ -5,7 +5,7 @@ require "tunit/mock"
 module Tunit::Faux::Reporters
   class TimesTest < Minitest::Test
     def test_run
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Times.new(method_name: :foo, times: 1, mock: mock)
 
       mock.foo
@@ -14,7 +14,7 @@ module Tunit::Faux::Reporters
     end
 
     def test_run_on_violation
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Times.new(method_name: :foo, times: 1, mock: mock)
 
       mock.foo
@@ -24,14 +24,14 @@ module Tunit::Faux::Reporters
     end
 
     def test_result_on_failure
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       reporter = Times.new(method_name: :foo, times: 1, mock: mock)
 
       mock.foo
       mock.foo
 
       exp_report = <<-EOS
-        Expected Tunit::Mock#foo[] to have been called 1 time, was called 2 times
+        Expected Tunit::Mock::Spy#foo[] to have been called 1 time, was called 2 times
       EOS
 
       assert_equal exp_report.strip, reporter.report

--- a/test/tunit/faux/settler_test.rb
+++ b/test/tunit/faux/settler_test.rb
@@ -5,7 +5,7 @@ require "tunit/mock"
 module Tunit::Faux
   class SettlerTest < Minitest::Test
     def test_satisfied_eh_method_name
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo)
 
       mock.foo
@@ -14,7 +14,7 @@ module Tunit::Faux
     end
 
     def test_satisfied_eh_arguments
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo, arguments: 1)
 
       mock.foo(1)
@@ -23,7 +23,7 @@ module Tunit::Faux
     end
 
     def test_satisfied_eh_arguments_by_type
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo, arguments: String)
 
       mock.foo("whatever")
@@ -32,7 +32,7 @@ module Tunit::Faux
     end
 
     def test_satisfied_eh_times
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo, times: 2)
 
       mock.foo
@@ -42,7 +42,7 @@ module Tunit::Faux
     end
 
     def test_reason_method_name
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo)
 
       mock.bar
@@ -50,14 +50,14 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo[] to have been called
+        Expected Tunit::Mock::Spy#foo[] to have been called
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip
     end
 
     def test_reason_arguments
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo, arguments: 1)
 
       mock.foo(2)
@@ -65,14 +65,14 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo[1] to have been called, was called with [2]
+        Expected Tunit::Mock::Spy#foo[1] to have been called, was called with [2]
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip
     end
 
     def test_reason_times
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(mock: mock, method_name: :foo, times: 2)
 
       mock.foo
@@ -80,14 +80,14 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo[] to have been called 2 times, was called 1 time
+        Expected Tunit::Mock::Spy#foo[] to have been called 2 times, was called 1 time
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip
     end
 
     def test_reason_times_with_arguments
-      mock = Tunit::Mock.new
+      mock = Tunit::Mock.new(:spy)
       settler = Settler.new(
         arguments: 1,
         method_name: :foo,
@@ -102,7 +102,7 @@ module Tunit::Faux
       refute_predicate settler, :satisfied?
 
       exp_message = <<-EOS.strip_heredoc
-        Expected Tunit::Mock#foo[1] to have been called 2 times, was called 3 times
+        Expected Tunit::Mock::Spy#foo[1] to have been called 2 times, was called 3 times
       EOS
 
       assert_equal exp_message.strip, settler.reason.strip

--- a/test/tunit/mock/base_test.rb
+++ b/test/tunit/mock/base_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "tunit/mock/base"
+
+module Tunit::Mock
+  class BaseTest < Minitest::Test
+    def test_calls
+      mock = Base.new
+
+      assert_instance_of Array, mock.calls
+      assert_empty mock.calls
+    end
+
+    def test_method_missing_gathers_calls
+      mock = Base.new
+
+      mock.foo(1)
+      mock.foo(2)
+
+      assert_equal 2, mock.calls.size
+    end
+
+    def test_method_missing_wraps_calls_as_an_object
+      mock = Base.new
+
+      mock.foo(1)
+      method_call = mock.calls.first
+
+      assert_equal :foo, method_call.method_name
+      assert_equal [1], method_call.arguments
+      assert_instance_of Proc, method_call.block
+    end
+
+    def test_method_missing_hides_its_implementation
+      mock = Base.new
+
+      assert_equal :foo, mock.foo(1)
+    end
+  end
+end

--- a/test/tunit/mock/double_test.rb
+++ b/test/tunit/mock/double_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "tunit/mock/double"
+
+module Tunit::Mock
+  class DoubleTest < Minitest::Test
+    def test_method_missing
+      double = Double.new(foo: nil)
+
+      double.foo
+      double.foo
+
+      assert_equal 2, double.calls.size
+    end
+
+    def test_method_missing_white_listed_method
+      double = Double.new(foo: 1, bar: 2, baz: 3)
+
+      assert_equal 1, double.foo
+      assert_equal 2, double.bar
+      assert_equal 3, double.baz
+    end
+
+    def test_method_missing_blacklisted_method
+      double = Double.new(foo: 1)
+
+      e = assert_raises Double::UnexpectedMethod do
+        double.bar
+      end
+
+      assert_equal "`bar' was not expected to be called", e.message
+    end
+  end
+end

--- a/test/tunit/mock/null_object_test.rb
+++ b/test/tunit/mock/null_object_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "tunit/mock/null_object"
+
+module Tunit::Mock
+  module ActsLikeANullObject
+    def test_method_missing_gathers_all_calls
+      mock = klass.new
+
+      mock.foo.bar.baz
+
+      assert_equal [:foo, :bar, :baz], mock.calls.map(&:method_name)
+    end
+
+    def test_method_missing_acts_as_a_null_object
+      mock = klass.new
+
+      assert_equal mock, mock.whatever
+    end
+  end
+
+  class NullObjectTest < Minitest::Test
+    include ActsLikeANullObject
+
+    def klass
+      NullObject
+    end
+  end
+
+  class SpyTest < Minitest::Test
+    include ActsLikeANullObject
+
+    def klass
+      Spy
+    end
+  end
+end

--- a/test/tunit/mock_test.rb
+++ b/test/tunit/mock_test.rb
@@ -3,46 +3,28 @@ require "tunit/mock"
 
 module Tunit
   class MockTest < Minitest::Test
-    def setup
-      @mock = Mock.new
-    end
-    attr_reader :mock
-
-    def test_name
-      mock = Mock.new(name: :my_mock)
-
-      assert_equal :my_mock, mock.name
-    end
-
-    def test_name_fallback
+    def test_new
       mock = Mock.new
 
-      assert_equal :mock, mock.name
+      assert_instance_of Mock::Double, mock
     end
 
-    def test_calls
-      assert_instance_of Array, mock.calls
-      assert_empty mock.calls
+    def test_new_unsupported_types
+      mock = Mock.new(:unsupported_type)
+
+      assert_instance_of Mock::Double, mock
     end
 
-    def test_method_missing_gathers_calls
-      mock.foo(1)
-      mock.foo(2)
+    def test_new_null_object
+      mock = Mock.new(:null_object)
 
-      assert_equal 2, mock.calls.size
+      assert_instance_of Mock::NullObject, mock
     end
 
-    def test_method_missing_wraps_calls_as_an_object
-      mock.foo(1)
-      method_call = mock.calls.first
+    def test_new_spy
+      mock = Mock.new(:spy)
 
-      assert_equal :foo, method_call.method_name
-      assert_equal [1], method_call.arguments
-      assert_instance_of Proc, method_call.block
-    end
-
-    def test_method_missing_hides_its_implementation
-      assert_equal :foo, mock.foo(1)
+      assert_instance_of Mock::Spy, mock
     end
   end
 end


### PR DESCRIPTION
- Use `Mock::Double` as the default mock-type.
  `Mock::Double` accepts a white-list of methods to be called, and gathers the
  calls made so assertions can be made which arguments was called with for the
  method on the double.
- Add `Mock::Spy`.
  It acts like a `Mock::NullObject`.
- Add `Mock::NullObject`.
  Fallback to `Mock::Base` for any unsupported mock-types
- Refactor: Support different kinds of Mocks
- Introduce `Mock::Base` for shared behavior.
  Each child-class of `Base` overrides `method_missing` to specify their
  own specific behavior.
